### PR TITLE
fix: Remove `--last-failed-no-failures=none` arg

### DIFF
--- a/pre_commit_hooks/diff_cover.py
+++ b/pre_commit_hooks/diff_cover.py
@@ -55,8 +55,6 @@ def run_pytest(configuration: Configuration) -> int:
                 "--failed-first",
                 "--new-first",  # run new tests first
                 "--last-failed",
-                # if no previous fails, skip all
-                "--last-failed-no-failures=none",
             ]
         )
 


### PR DESCRIPTION
This appears to be causing some mis-reporting of results in `diff-cover`, so consider this a quick fix to the current issue.